### PR TITLE
add variable to set inet_protocols to ipv4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ If you're using this as an SMTP relay server, you will need to do that on your o
 
 ## Role Variables
 
-None.
+    postfix_ipv4: true
+
+Set `postfix_ipv4` to `true` to add `inet_protocols = ipv4` in the postfix conf which may resolve some networking issues when delivering mail.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,2 @@
 ---
+postfix_ipv4 == 'false'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-postfix_ipv4 == 'false'
+postfix_ipv4: 'false'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,5 +7,8 @@
   apt: name=postfix state=installed
   when: ansible_os_family == 'Debian'
 
+- lineinfile: dest="/etc/postfix/main.cf" line="inet_protocols = ipv4"
+  when: postfix_ipv4 == 'true'
+
 - name: Ensure postfix is started and enabled at boot.
   service: name=postfix state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,5 +10,8 @@
 - lineinfile: dest="/etc/postfix/main.cf" line="inet_protocols = ipv4"
   when: postfix_ipv4 == 'true'
 
+- lineinfile: dest="/etc/postfix/main.cf" line="inet_protocols = ipv4" state=absent
+  when: postfix_ipv4 == 'false'
+
 - name: Ensure postfix is started and enabled at boot.
   service: name=postfix state=started enabled=yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,7 +3,7 @@
 
   pre_tasks:
     - name: Update apt cache.
-      apt: update_cache=yes
+      apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
 
   roles:


### PR DESCRIPTION
In some cases there may be an issue when delivering mail if the variable `inet_protocols` is not set to `ipv4`. Arguably going ipv4 is a bit backward in 2016 but having the option available may allow people to not work around this role to resolve this.

I realise this role has no variables available yet and this may be for specific reason, opening the PR anyway as it may be beneficial to some.