### PR TITLE
Adds an option to enable relaying to MailHog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ The state in which the Postfix service should be after this role runs, and wheth
 
 Options for values `inet_interfaces` and `inet_protocols` in the `main.cf` file.
 
+    postfix_relay_to_mailhog: no
+
+Option to enable relaying to MailHog on the localhost, port 1025. Requires [MailHog](https://github.com/geerlingguy/ansible-role-mailhog) to be installed on localhost.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ postfix_service_enabled: yes
 
 postfix_inet_interfaces: localhost
 postfix_inet_protocols: all
+
+postfix_relay_to_mailhog: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,14 @@
       value: "{{ postfix_inet_protocols }}"
   notify: restart postfix
 
+- name: Enable relay to MailHog.
+  lineinfile:
+    dest: "{{ postfix_config_file }}"
+    line: "relayhost = 127.0.0.1:1025"
+    regexp: "^relayhost ="
+  when: postfix_relay_to_mailhog
+  notify: restart postfix
+
 - name: Ensure postfix is started and enabled at boot.
   service:
     name: postfix


### PR DESCRIPTION
# Why
This PR is to add the option of relaying SMTP trafic to MailHog.

In development environments, it can be crucial that real email addresses do not receive test messages.

By adding this option, it ensures that SMTP traffic is relayed to MailHog and not onward to to the public internet.

It is intended as a belt and braces method, as most applications should be developed with the option to set SMTP details per environment, rather than relying upon people being careful.

The addition to this role will also allow testing of system services that need to send emails (such as unattended updates) without having to configure a real SMTP relay, such as sendgrid, railgun, mailchimp, etc.

# Acceptance Criteria
* [ ] Doesn't break existing functionality
* [ ] Documentation has been updated
* [ ] SMTP relayed to MailHog when enabled
 
# How I tested
* Created a playbook that used this role and also installed MailHog
* In group_vars, set the option `postfix_relay_to_mailhog` to `yes`
* Provisioned a VM using ansible
* SSHd to the VM and checked `/etc/postfix/main.cf` had the correct value for the `relayhost`
* Installed `mutt` on the VM and sent an email to a real email address
* Loaded MailHog in a browser and saw that the email had been caught