### PR TITLE
Switch to more flexible dict for configuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ The path to the Postfix `main.cf` configuration file.
 
 The state in which the Postfix service should be after this role runs, and whether to enable the service on startup.
 
-    postfix_inet_interfaces: localhost
-    postfix_inet_protocols: all
+    postfix_config:
+      inet_interfaces: localhost
+      inet_protocols: all
 
-Options for values `inet_interfaces` and `inet_protocols` in the `main.cf` file.
+The `postfix_config` can be used to add/update any postfix confiuration option; defaults set `inet_interfaces` and `inet_protocols` in the `main.cf` file.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,6 @@ postfix_config_file: /etc/postfix/main.cf
 postfix_service_state: started
 postfix_service_enabled: true
 
-postfix_inet_interfaces: localhost
-postfix_inet_protocols: all
+postfix_config:
+  inet_interfaces: localhost
+  inet_protocols: all

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,9 @@
 - name: Update Postfix configuration.
   lineinfile:
     dest: "{{ postfix_config_file }}"
-    line: "{{ item.name }} = {{ item.value }}"
-    regexp: "^{{ item.name }} ="
-  with_items:
-    - name: inet_interfaces
-      value: "{{ postfix_inet_interfaces }}"
-    - name: inet_protocols
-      value: "{{ postfix_inet_protocols }}"
+    line: "{{ item.key }} = {{ item.value }}"
+    regexp: "^{{ item.key }} ="
+  with_dict: "{{ postfix_config }}"
   notify: restart postfix
 
 - name: Ensure postfix is started and enabled at boot.


### PR DESCRIPTION
Allows for configuring pretty much any setting in the main.cf file without adding any major complexity overhead to the role