### PR TITLE
Add to default test coverage

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -6,9 +6,21 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_hosts_file(host):
-    f = host.file('/etc/hosts')
+def test_postfix_package(host):
+    pkg = host.package('postfix')
 
-    assert f.exists
-    assert f.user == 'root'
-    assert f.group == 'root'
+    assert pkg.is_installed
+
+
+def test_postfix_service(host):
+    service = host.service('postfix')
+
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_postfix_config_file(host):
+    f = host.file('/etc/postfix/main.cf')
+
+    assert f.is_file
+    assert f.contains(r'^inet_interfaces = localhost$')


### PR DESCRIPTION
This adds very basic tests for the role's tasks.

I left out a matcher for the default value of postfix's `inet_protocols` parameter because it varies by platform in this playbook. I'm new to Ansible/Molecule and not entirely sure how best to separate tests based on platform, and it seems the current layout just hinges on the `MOLECULE_DISTRO` variable. (Would the proper approach be using scenarios representative of platforms? Input is welcome.)