### PR TITLE
Turn postfix config options into a generic hash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ The path to the Postfix `main.cf` configuration file.
 
 The state in which the Postfix service should be after this role runs, and whether to enable the service on startup.
 
-    postfix_inet_interfaces: localhost
-    postfix_inet_protocols: all
+    postfix_config:
+      - name: inet_interfaces
+        value: localhost
+      - name: inet_protocols
+        value: all
 
 Options for values `inet_interfaces` and `inet_protocols` in the `main.cf` file.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,8 @@ postfix_config_file: /etc/postfix/main.cf
 postfix_service_state: started
 postfix_service_enabled: true
 
-postfix_inet_interfaces: localhost
-postfix_inet_protocols: all
+postfix_config:
+  - name: inet_interfaces
+    value: "{{ postfix_inet_interfaces|default('localhost') }}"
+  - name: inet_protocols
+    value: "{{ postfix_inet_protocols|default('all') }}"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -10,7 +10,9 @@
 
     - name: Override postfix_inet_protocols (RHEL).
       set_fact:
-        postfix_inet_protocols: ipv4
+        postfix_config:
+          - name: inet_protocols
+            value: ipv4
       when: ansible_os_family == 'RedHat'
 
   roles:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Update Postfix configuration.
   lineinfile:
     dest: "{{ postfix_config_file }}"
-    line: "{{ item.name }} = {{ item.value }}"
+    line: "{{ item.name }} = {{ vars['postfix_' + item.name]|default(item.value) }}"
     regexp: "^{{ item.name }} ="
   with_items: "{{ postfix_config }}"
   notify: restart postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,11 +9,7 @@
     dest: "{{ postfix_config_file }}"
     line: "{{ item.name }} = {{ item.value }}"
     regexp: "^{{ item.name }} ="
-  with_items:
-    - name: inet_interfaces
-      value: "{{ postfix_inet_interfaces }}"
-    - name: inet_protocols
-      value: "{{ postfix_inet_protocols }}"
+  with_items: "{{ postfix_config }}"
   notify: restart postfix
 
 - name: Ensure postfix is started and enabled at boot.


### PR DESCRIPTION
## WHY

This allows you to easily set or override *any* single-line postfix configuration variable without the need to explicitly list it in the task. Less work is more good, right?

☑️ Seems to not break tests.