### PR TITLE
Changed the format for specifying options for postfix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ The state in which the Postfix service should be after this role runs, and wheth
     postfix_inet_interfaces: localhost
     postfix_inet_protocols: all
 
-Options for values `inet_interfaces` and `inet_protocols` in the `main.cf` file.
+    postfix_config_options:
+    - option: 'inet_interfaces'
+        value: '{{ postfix_inet_interfaces }}'
+    - option: 'inet_protocols'
+        value: '{{ postfix_inet_protocols }}'
+    - option: 'relayhost'
+        value: '[localhost]'
+        insertafter: '#relayhost'
+
+Global configuration options that will be set in `{{ postfix_config_file }}`.  If you need to define additional values
+you will have to redefine the values in the default.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ The state in which the Postfix service should be after this role runs, and wheth
         value: '{{ postfix_inet_interfaces }}'
     - option: 'inet_protocols'
         value: '{{ postfix_inet_protocols }}'
-    - option: 'relayhost'
-        value: '[localhost]'
-        insertafter: '#relayhost'
 
 Global configuration options that will be set in `{{ postfix_config_file }}`.  If you need to define additional values
 you will have to redefine the values in the default.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,3 @@ postfix_config_options:
     value: "{{ postfix_inet_interfaces }}"
   - option: "inet_protocols"
     value: "{{ postfix_inet_protocols }}"
-  - option: "relayhost"
-    value: "[localhost]"
-    insertafter: "#relayhost"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,12 @@ postfix_service_enabled: true
 
 postfix_inet_interfaces: localhost
 postfix_inet_protocols: all
+
+postfix_config_options:
+  - option: "inet_interfaces"
+    value: "{{ postfix_inet_interfaces }}"
+  - option: "inet_protocols"
+    value: "{{ postfix_inet_protocols }}"
+  - option: "relayhost"
+    value: "[localhost]"
+    insertafter: "#relayhost"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,12 @@
 - name: Update Postfix configuration.
   lineinfile:
     dest: "{{ postfix_config_file }}"
-    line: "{{ item.name }} = {{ item.value }}"
-    regexp: "^{{ item.name }} ="
-  with_items:
-    - name: inet_interfaces
-      value: "{{ postfix_inet_interfaces }}"
-    - name: inet_protocols
-      value: "{{ postfix_inet_protocols }}"
+    line: "{{ item.option }} = {{ item.value }}"
+    regexp: "^{{ item.option }}\\s*="
+    insertbefore: "{{ item.insertbefore | default(omit) }}"
+    insertafter: "{{ item.insertafter | default(omit) }}"
+    state: "{{ item.state | default('present') }}"
+  with_items: "{{ postfix_config_options }}"
   notify: restart postfix
 
 - name: Ensure postfix is started and enabled at boot.


### PR DESCRIPTION
I change to way to define config options for postfix to be similar to the way you do it for postresql.  This allows the user to add additional option to the config without modifying the role.