### PR TITLE
Add variable to set extra parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ The state in which the Postfix service should be after this role runs, and wheth
 
 Options for values `inet_interfaces` and `inet_protocols` in the `main.cf` file.
 
+    postfix_extra_parameters:
+        - { name: 'maximal_queue_lifetime', value: '1h' }
+        - { name: 'maximal_backoff_time', value: '15m' }
+        - { name: 'minimal_backoff_time', value: '5m' }
+        - { name: 'queue_run_delay', value: '5m' }
+
+Extra parameters in the `main.cf` file.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ postfix_service_enabled: true
 
 postfix_inet_interfaces: localhost
 postfix_inet_protocols: all
+
+postfix_extra_parameters: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,15 @@
       value: "{{ postfix_inet_protocols }}"
   notify: restart postfix
 
+- name: Update Postfix extra parameters.
+  lineinfile:
+    dest: "{{ postfix_config_file }}"
+    line: "{{ item.name }} = {{ item.value }}"
+    regexp: "^{{ item.name }} ="
+    mode: 0644
+  with_items: "{{ postfix_extra_parameters | default([], true) }}"
+  notify: restart postfix
+
 - name: Ensure postfix is started and enabled at boot.
   service:
     name: postfix


### PR DESCRIPTION
This PR will allow to add extra parameters to the main.cf file.

Similar to PR #6, #10 and #12, but does not require the user to change the current role variables 