### PR TITLE
Extending role to include more configuration options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs postfix on RedHat/CentOS or Debian/Ubuntu.
 
 ## Requirements
 
-If you're using this as an SMTP relay server, you will need to do that on your own, and open TCP port 25 in your server firewall.
+If you're using this as an SMTP relay server, you will need to open TCP port 25 in your server firewall.
 
 ## Role Variables
 
@@ -24,7 +24,32 @@ The state in which the Postfix service should be after this role runs, and wheth
     postfix_inet_interfaces: localhost
     postfix_inet_protocols: all
 
-Options for values `inet_interfaces` and `inet_protocols` in the `main.cf` file.
+Options for values `inet_interfaces` and `inet_protocols` in the `main.cf` file. 
+
+    postfix_smtpd_banner
+    postfix_mynetworks
+    postfix_smtpd_tls_cert_file
+    postfix_smtpd_tls_key_file
+    postfix_smtpd_tls_security_level
+    postfix_maillog_file
+    postfix_myhostname
+    postfix_smtpd_relay_restrictions
+    postfix_mydestination
+
+Options that will be set if the built-in template is used.
+
+    postfix_templates
+
+List of `src` and `dest` with templates to deploy.
+
+    postfix_transport_template
+    postfix_transport_file
+
+Options for the postfix tranport file and template. This is handeled outside of other templates because it has to be managed in a different way.
+
+    postfix_transports
+
+List of entries for the postfix transports file.
 
 ## Dependencies
 
@@ -35,6 +60,20 @@ None.
     - hosts: all
       roles:
         - geerlingguy.postfix
+      vars:
+        postfix_templates:
+          - src: main.cf.j2
+            dest: /etc/postfix/main.cf
+          - src: master.cf.j2
+            dest: /etc/postfix/master.cf
+            mode: 0664
+            owner: root
+            group: postfix
+        postfix_transports:
+          - pattern: *@subdomain.example.com
+            method: smtp
+            nexthop: 10.0.0.2
+        postfix_dkim_socket: "unix:/opendkim/opendkim.sock"
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,12 @@ postfix_service_enabled: true
 
 postfix_inet_interfaces: localhost
 postfix_inet_protocols: all
+
+postfix_smtpd_banner: $myhostname ESMTP $mail_name (Debian/GNU)
+
+postfix_mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+
+postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
+postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+postfix_smtpd_tls_security_level: may
+postfix_myhostname: "{{ inventory_hostname }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,6 @@ postfix_mynetworks: 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
 postfix_smtpd_tls_security_level: may
+
+postfix_maillog_file: /var/log/postfix.log
 postfix_myhostname: "{{ inventory_hostname }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,9 @@ postfix_smtpd_tls_security_level: may
 
 postfix_maillog_file: /var/log/postfix.log
 postfix_myhostname: "{{ inventory_hostname }}"
+
+postfix_transport_template: transport.j2
+postfix_transport_file: /etc/postfix/transport
+
+postfix_smtpd_relay_restrictions: permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+postfix_mydestination: $myhostname, localdomain, localhost, localhost.localdomain, localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,18 @@
   when: postfix_template is defined
   notify: restart postfix
 
+- name: Apply transport template if any transport rule is defined
+  template:
+    src: "{{ postfix_transport_template }}"
+    dest: "{{ postfix_transport_file }}"
+    mode: 0644
+  when: postfix_transport is defined
+  register: transport_file
+
+- name: Build postmap
+  command: postmap {{ postfix_transport_file }}
+  when: transport_file.changed
+
 - name: Ensure postfix is started and enabled at boot.
   service:
     name: postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,15 @@
       value: "{{ postfix_inet_interfaces }}"
     - name: inet_protocols
       value: "{{ postfix_inet_protocols }}"
+  when: postfix_template is not defined
+  notify: restart postfix
+
+- name: Apply Postfix template
+  template:
+    dest: "{{ postfix_config_file }}"
+    src: "{{ postfix_template }}"
+    mode: 0644
+  when: postfix_template is defined
   notify: restart postfix
 
 - name: Ensure postfix is started and enabled at boot.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,15 +15,18 @@
       value: "{{ postfix_inet_interfaces }}"
     - name: inet_protocols
       value: "{{ postfix_inet_protocols }}"
-  when: postfix_template is not defined
+  when: postfix_templates is not defined
   notify: restart postfix
 
-- name: Apply Postfix template
+- name: Apply Postfix templates
   template:
-    dest: "{{ postfix_config_file }}"
-    src: "{{ postfix_template }}"
-    mode: 0644
-  when: postfix_template is defined
+    dest: "{{ item.dest }}"
+    src: "{{ item.src }}"
+    mode: "{{ item.mode | default('0644') }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+  when: postfix_templates is defined
+  loop: "{{ postfix_templates }}"
   notify: restart postfix
 
 - name: Apply transport template if any transport rule is defined
@@ -37,6 +40,7 @@
 - name: Build postmap
   command: postmap {{ postfix_transport_file }}
   when: transport_file.changed
+  notify: restart postfix
 
 - name: Ensure postfix is started and enabled at boot.
   service:

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -1,0 +1,50 @@
+# See /usr/share/postfix/main.cf.dist for a commented, more complete version
+
+
+# Debian specific:  Specifying a file name will cause the first
+# line of that file to be used as the name.  The Debian default
+# is /etc/mailname.
+#myorigin = /etc/mailname
+
+smtpd_banner = {{ postfix_smtpd_banner }}
+biff = no
+
+# appending .domain is the MUA's job.
+append_dot_mydomain = no
+
+{% if postfix_delay_warning_time is defined %}
+delay_warning_time = {{ postfix_delay_warning_time}}
+{% endif %}
+
+readme_directory = no
+
+# See http://www.postfix.org/COMPATIBILITY_README.html -- default to 3.6 on
+# fresh installs.
+compatibility_level = 3.6
+
+
+
+# TLS parameters
+smtpd_tls_cert_file={{ postfix_smtpd_tls_cert_file }}
+smtpd_tls_key_file={{ postfix_smtpd_tls_key_file }}
+smtpd_tls_security_level={{ postfix_smtpd_tls_security_level }}
+
+smtp_tls_CApath=/etc/ssl/certs
+smtp_tls_security_level=may
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+
+
+smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+myhostname = {{ postfix_myhostname }}
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+mydestination = $myhostname, localdomain, localhost, localhost.localdomain, localhost
+relayhost = 
+mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+{% if postfix_mynetworks_style is defined %}
+mynetworks_style = {{ postfix_mynetworks_style }}
+{% endif %}
+mailbox_size_limit = 0
+recipient_delimiter = +
+inet_interfaces = {{ postfix_inet_interfaces }}
+inet_protocols = {{ postfix_inet_protocols }}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -22,7 +22,7 @@ readme_directory = no
 # fresh installs.
 compatibility_level = 3.6
 
-
+{% if postfix_maillog_file is defined %}maillog_file = {{ postfix_maillog_file }}{% endif %}
 
 # TLS parameters
 smtpd_tls_cert_file={{ postfix_smtpd_tls_cert_file }}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -24,9 +24,14 @@ readme_directory = no
 # fresh installs.
 compatibility_level = 3.6
 
-{% if postfix_maillog_file is defined %}maillog_file = {{ postfix_maillog_file }}{% endif %}
+{% if postfix_maillog_file is defined %}
+maillog_file = {{ postfix_maillog_file }}
+{% endif %}
 
 # TLS parameters
+{% if postfix_smtpd_tls_security_level is defined %}
+smtpd_tls_security_level = {{ postfix_smtpd_tls_security_level }}
+{% endif %}
 smtpd_tls_cert_file={{ postfix_smtpd_tls_cert_file }}
 smtpd_tls_key_file={{ postfix_smtpd_tls_key_file }}
 smtpd_tls_security_level={{ postfix_smtpd_tls_security_level }}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -48,3 +48,9 @@ mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = {{ postfix_inet_interfaces }}
 inet_protocols = {{ postfix_inet_protocols }}
+
+{% if postfix_dkim_socket is defined %}
+smtpd_milters = {{ postfix_dkim_socket }}
+non_smtpd_milters = $smtpd_milters
+milter_default_action = accept
+{% endif %}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -35,13 +35,15 @@ smtp_tls_CApath=/etc/ssl/certs
 smtp_tls_security_level=may
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
-smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+smtpd_relay_restrictions = {{ postfix_smtpd_relay_restrictions }}
 
 myhostname = {{ postfix_myhostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
-mydestination = $myhostname, localdomain, localhost, localhost.localdomain, localhost
-relayhost = 
+mydestination = {{ postfix_mydestination }}
+{% if postfix_relayhost is defined %}
+relayhost = {{ postfix_relayhost }}
+{% endif %}
 mynetworks = {{ postfix_mynetworks }}
 {% if postfix_mynetworks_style is defined %}
 mynetworks_style = {{ postfix_mynetworks_style }}
@@ -55,4 +57,8 @@ inet_protocols = {{ postfix_inet_protocols }}
 smtpd_milters = {{ postfix_dkim_socket }}
 non_smtpd_milters = $smtpd_milters
 milter_default_action = accept
+{% endif %}
+
+{% if postfix_transport_file is defined and postfix_transports is defined %}
+transport_maps = {{ postfix_transport_file }}
 {% endif %}

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -1,5 +1,7 @@
-# See /usr/share/postfix/main.cf.dist for a commented, more complete version
-
+ ####################################
+ # This file is managed by Ansible. #
+ # Any changes will be overwritten. #
+ ####################################
 
 # Debian specific:  Specifying a file name will cause the first
 # line of that file to be used as the name.  The Debian default
@@ -33,14 +35,14 @@ smtp_tls_CApath=/etc/ssl/certs
 smtp_tls_security_level=may
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
-
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+
 myhostname = {{ postfix_myhostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 mydestination = $myhostname, localdomain, localhost, localhost.localdomain, localhost
 relayhost = 
-mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+mynetworks = {{ postfix_mynetworks }}
 {% if postfix_mynetworks_style is defined %}
 mynetworks_style = {{ postfix_mynetworks_style }}
 {% endif %}

--- a/templates/transport.j2
+++ b/templates/transport.j2
@@ -1,0 +1,3 @@
+{% for entry in postfix_transports %}
+{{ entry.pattern }}	{{ entry.method }}:{{ entry.nexthop }}
+{% endfor %}


### PR DESCRIPTION
So this became a larger pull request than initially intended.

I wanted a mail transport server for serving my home lab with valid emails. There are enough config options in this commit to support creating both a legitimate mail server and a local relay. 

Headline additions:

- Templates
Support for deploying arbitrary templates have been added. A main.cf template is included.

Also support for integrating the following has been added:
- DKIM
- TLS
- Relaying

